### PR TITLE
Update instruction ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ Myth supports only a part of the ocaml syntax. We need a translator that takes i
 
 2. dune build && dune install
 
-### Lemmafinder
-We are now ready to make this project.
-Run `cd lemmafinder && opam config subst theories/LFindLoad.v && dune build && dune build && dune install`
-
 ### Environment Setup
 In the folder that you run make or coqc export the following environment variable
 
@@ -100,6 +96,10 @@ export COQOFOCAML=/Users/<username>/.opam/4.07.1+flambda/bin/coq-of-ocaml
 export REWRITE=<path to ast_rewriter>/_build/default/bin/main.exe
 export LFIND=<path to lemma finder source>
 ```
+
+### Lemmafinder
+We are now ready to make this project.
+Run `cd lemmafinder && opam config subst theories/LFindLoad.v && dune build && dune build && dune install`
 </details>
 
 ## Lemma Synthesis

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Synthesize a required helper lemma by invoking lfind as follows, making sure to 
 ```
 cd <path to lfind>
 cd benchmark/motivating_example && make && cd ../../
-python3 benchmark/run.py --prelude=<path to lfind>/benchmark/motivating_example --log_dir=<path to log directory> --getting_started
+python3 benchmark/run.py --prelude=<path to lfind>/benchmark/motivating_example --log_dir=<path to log directory> --getting_started -b $PWD/benchmark/motivating_example
 ```
 
 This should take ~5min and you should see the following synthesized lemma as the output of the script.


### PR DESCRIPTION
lfind build fails if the prover path is not set, so we need to do that first.