### PR TITLE
Update coq-synth flag name

### DIFF
--- a/src/CoqSynth.ml
+++ b/src/CoqSynth.ml
@@ -8,7 +8,7 @@ let run p_ctxt conjecture_name examples params output_type=
   let funcs = String.concat "," p_ctxt.funcs
   in let examples_op = String.concat " " examples
   in let timeout_cmd = Consts.fmt "timeout  %s" Consts.synthesizer_timeout
-  in let coq_synth_cmd = Consts.fmt  "%s --logical-dir=%s --physical-dir='%s' --module=%s --type=%s --params=%s --extra-vars=%s --examples='%s' --num-terms=%d > %s" coq_synth_path p_ctxt.namespace p_ctxt.original_dir p_ctxt.fname output_type params funcs examples_op Consts.myth_batch_size coq_synth_output_path
+  in let coq_synth_cmd = Consts.fmt  "%s --logical-dir=%s --physical-dir='%s' --module=%s --type=%s --params=%s --extra-exprs=%s --examples='%s' --num-terms=%d > %s" coq_synth_path p_ctxt.namespace p_ctxt.original_dir p_ctxt.fname output_type params funcs examples_op Consts.myth_batch_size coq_synth_output_path
   in Log.debug (Consts.fmt "CoqSynth Command is %s\n"  (Consts.fmt "%s %s" timeout_cmd  coq_synth_cmd));
   let run_myth = run_cmd (Consts.fmt "%s %s" timeout_cmd  coq_synth_cmd)
   in (List.rev (read_file coq_synth_output_path))


### PR DESCRIPTION
Update `--extra-vars` flag to `--extra-exprs` due to interface change in https://github.com/qsctr/coq-synth/commit/ef70a741a05d5bf1ec8e9b6ab107b64f9277257f