### PR TITLE
fix myth example generation

### DIFF
--- a/app/g_lfind.mlg
+++ b/app/g_lfind.mlg
@@ -6,10 +6,14 @@ open Ltac_plugin
 
 TACTIC EXTEND lfind_tac
 | [ "lfind" ] -> { Lfind_main.lfind_tac false "coqsynth"}
+| [ "lfind_coqsynth" ] -> { Lfind_main.lfind_tac false "coqsynth"}
+| [ "lfind_myth" ] -> { Lfind_main.lfind_tac false "myth"}
 END
 
 TACTIC EXTEND lfind_debug_tac
 | [ "lfind_debug" ] -> { Lfind_main.lfind_tac true "coqsynth"}
+| [ "lfind_debug_coqsynth" ] -> { Lfind_main.lfind_tac true "coqsynth"}
+| [ "lfind_debug_myth" ] -> { Lfind_main.lfind_tac true "myth"}
 END
 
 VERNAC COMMAND EXTEND Success CLASSIFIED AS QUERY

--- a/app/lfind_main.ml
+++ b/app/lfind_main.ml
@@ -127,7 +127,7 @@ let lfind_tac (debug: bool) (synthesizer: string) : unit Proofview.tactic =
     if String.equal is_running "true" then Tacticals.New.tclZEROMSG (Pp.str ("LFind is already running! Aborting"))
     else
       begin
-        Utils.env_setup;
+        Utils.env_setup ();
         let contanins_forall, curr_state_lemma, typs, var_typs, vars, hyps = construct_state_as_lemma gl
         in print_endline curr_state_lemma;
         let p_ctxt, c_ctxt = construct_proof_context gl
@@ -185,13 +185,11 @@ let lfind_tac (debug: bool) (synthesizer: string) : unit Proofview.tactic =
         
         let coq_examples = Examples.dedup_examples (FileUtils.read_file example_file)
         in LogUtils.write_tbl_list_to_log coq_examples "Coq Examples";
-        let ml_examples = []
-        in if String.equal synthesizer "myth" then
+        let ml_examples = if String.equal synthesizer "myth" then
         (
-          let ml_examples = Examples.get_ml_examples coq_examples p_ctxt
-          in LogUtils.write_tbl_list_to_log ml_examples "ML Examples";
-        );
-        
+          Examples.get_ml_examples coq_examples p_ctxt
+        ) else coq_examples
+        in LogUtils.write_tbl_list_to_log ml_examples "ML Examples";
         let op = FileUtils.run_cmd "export is_lfind=true"
         in let abstraction = Abstract_NoDup.abstract
         in let generalized_terms, conjectures = abstraction p_ctxt c_ctxt
@@ -209,7 +207,7 @@ let lfind_tac (debug: bool) (synthesizer: string) : unit Proofview.tactic =
 
         (* get ml and coq version of the output of generalized terms *)
         let coq_examples, ml_examples = (ExampleUtils.evaluate_terms generalized_terms coq_examples ml_examples p_ctxt)
-        in
+        in 
         List.iter (fun c -> LogUtils.write_tbl_to_log c "COQE") coq_examples;
         
         let valid_conjectures, invalid_conjectures = (Valid.split_as_true_and_false conjectures p_ctxt)

--- a/src/Evaluate.ml
+++ b/src/Evaluate.ml
@@ -92,8 +92,7 @@ let evaluate_coq_expr expr examples p_ctxt all_vars
   *)
   let coq_output  = (List.rev (get_expr_vals output))
   in 
-  let ml_output = []
-  in if String.equal synthesizer "myth" then
+  let ml_output = if String.equal synthesizer "myth" then
   (
     let names, defs = get_defs_evaluated_examples coq_output
     in let ext_coqfile = generate_ml_extraction_file p_ctxt names defs
@@ -102,8 +101,6 @@ let evaluate_coq_expr expr examples p_ctxt all_vars
     in
     let ext_mlfile = Consts.fmt "%s/lfind_extraction.ml" p_ctxt.dir
     in let ext_output = List.rev (FileUtils.read_file ext_mlfile)
-    in let ml_output = List.rev (get_ml_evaluated_examples ext_output)
-    in Log.debug (Consts.fmt "length of examples %d\n" (List.length examples));
-    Log.debug (Consts.fmt "length of extracted examples %d\n" (List.length ml_output));
-  );
+    in List.rev (get_ml_evaluated_examples ext_output)
+  ) else [] in
   (coq_output, ml_output)

--- a/src/Examples.ml
+++ b/src/Examples.ml
@@ -58,6 +58,8 @@ let get_example_index examplestr index examples vars_for_synthesis lfind_sigma =
                     in 
                     if ind == ((List.length vars_for_synthesis)-1) then
                     (examplestr ^ op, ind+1)
+                    else if String.equal !Consts.synthesizer "myth" then
+                    (examplestr ^ op ^ " => ", ind+1)
                     else
                     ((examplestr ^ op ^ " , "), ind+1)
                  ) ("", 0) vars_for_synthesis
@@ -71,5 +73,7 @@ let gen_synthesis_examples (examples:(string, string) Hashtbl.t list)
              fun index op ->
                   let input_str,_ = get_example_index "" index examples vars_for_synthesis lfind_sigma
                   in 
-                  input_str ^ "=" ^ op ^ ";"
+                  if String.equal !Consts.synthesizer "myth"
+                  then (if Int.equal 0 index then input_str ^ " => " ^ op else input_str ^ " => " ^ op ^ ";")
+                  else input_str ^ "=" ^ op ^ ";"
             ) output_examples

--- a/src/Utils.ml
+++ b/src/Utils.ml
@@ -168,7 +168,7 @@ let cpu_count () =
     )
   with  _ -> 1
   
-let env_setup : unit =
+let env_setup () =
   let prover_path = get_env_var Consts.prover
   in
   if String.equal prover_path "" then raise (Invalid_Env "Prover path not set!")


### PR DESCRIPTION
Mostly fixing the Myth example generation. The examples generated for CoqSynth and Myth differ slightly in syntax, so now the correct examples are used. 